### PR TITLE
Support PNG images and document image upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# TagSense Demo
+
+This repository contains a simple demo for an image privacy pre-processor. The web page in `index.html` lets you choose an image and apply an action (blur, hide, or replace) to reveal the processed result.
+
+## Adding Images
+
+1. Place all input and output images in the [`images/`](images/) folder.
+2. The app expects the following naming convention:
+   - Input: `security.png`, `privacy.png`, `compliance.png`
+   - Output: `<name>_blur.png`, `<name>_hide.png`, `<name>_replace.png`
+3. After adding your images, commit and push:
+```bash
+git add images/
+git commit -m "Add privacy demo images"
+git push
+```
+
+## Running Locally
+Open `index.html` in your browser to test the demo locally.

--- a/images/README.md
+++ b/images/README.md
@@ -1,0 +1,21 @@
+# Images
+
+Place your input images (`security.png`, `privacy.png`, `compliance.png`) and their processed outputs here.
+
+Expected output filenames:
+- `security_blur.png`
+- `security_hide.png`
+- `security_replace.png`
+- `privacy_blur.png`
+- `privacy_hide.png`
+- `privacy_replace.png`
+- `compliance_blur.png`
+- `compliance_hide.png`
+- `compliance_replace.png`
+
+Add the files via Git and push to GitHub:
+```bash
+git add images/
+git commit -m "Add images"
+git push
+```

--- a/index.html
+++ b/index.html
@@ -20,9 +20,9 @@
 
 <!-- Image selection gallery -->
 <div id="image-selector">
-  <img src="images/security.jpg" alt="Security Risk" onclick="selectImage(this)" />
-  <img src="images/privacy.jpg" alt="Privacy Risk" onclick="selectImage(this)" />
-  <img src="images/compliance.jpg" alt="Compliance Risk" onclick="selectImage(this)" />
+  <img src="images/security.png" alt="Security Risk" onclick="selectImage(this)" />
+  <img src="images/privacy.png" alt="Privacy Risk" onclick="selectImage(this)" />
+  <img src="images/compliance.png" alt="Compliance Risk" onclick="selectImage(this)" />
 </div>
 
 <!-- Preview of selected image -->
@@ -66,7 +66,7 @@
   function applyAction() {
     const action = document.getElementById('actionSelect').value;
     if (!selectedImageBase) return;
-    const outputPath = `images/${selectedImageBase}_${action}.jpg`;
+    const outputPath = `images/${selectedImageBase}_${action}.png`;
     const outImg = document.getElementById('outputImage');
     outImg.src = outputPath;
     outImg.style.display = 'block';


### PR DESCRIPTION
## Summary
- Reference PNG files for security, privacy and compliance demo images
- Document how to add source and processed images
- Stub out `images/` directory for uploads

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a320b99883238e12a73ccd5017dc