### PR TITLE
feat: add Chrome extension manifest

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta http-equiv="origin-trial" content="ArFm9aFw4tyKDX4T31yRBGjMO8zBwMfVSxXkdd+q6/8xFBxaFrPudMOtk3zUVY79+0Z0jTVHHwBCht5fm8vFfgIAAABmeyJvcmlnaW4iOiJodHRwczovL3NvbnU4NGl0LmdpdGh1Yi5pbzo0NDMiLCJmZWF0dXJlIjoiQUlQcm9tcHRBUElNdWx0aW1vZGFsSW5wdXQiLCJleHBpcnkiOjE3NzQzMTA0MDB9" />
   <title>Image Privacy Pre-processor Prototype</title>
   <link rel="stylesheet" href="./style.css" />
 </head>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,14 @@
+{
+  "manifest_version": 3,
+  "name": "TagSense Demo",
+  "version": "1.0",
+  "description": "Image privacy pre-processor prototype as a Chrome extension.",
+  "action": {
+    "default_popup": "index.html"
+  },
+  "origin_trials": [
+    {
+      "id": "ArFm9aFw4tyKDX4T31yRBGjMO8zBwMfVSxXkdd+q6/8xFBxaFrPudMOtk3zUVY79+0Z0jTVHHwBCht5fm8vFgIAAABmeyJvcmlnaW4iOiJodHRwczovL3NvbnU4NGl0LmdpdGh1Yi5pbzo0NDMiLCJmZWF0dXJlIjoiQUlQcm9tcHRBUElNdWx0aW1vZGFsSW5wdXQiLCJleHBpcnkiOjE3NzQzMTA0MDB9"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Chrome extension manifest with origin trial token
- use index.html as extension popup and remove in-page token

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ae4d41e48323b922a574eb6499ff