### PR TITLE
Add multimodal comparison and audio capture

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
   <div id="rightPane">
     <h2>Result</h2>
     <img id="outputImage" src="" alt="Output Image" style="display: none;" onclick="analyzeImage(this)" />
+    <pre id="analysisResult"></pre>
   </div>
 </div>
 

--- a/main.js
+++ b/main.js
@@ -19,6 +19,7 @@ function applyAction() {
   const outImg = document.getElementById('outputImage');
   outImg.src = outputPath;
   outImg.style.display = 'block';
+  compareImages();
 }
 
 async function analyzeImage(imgElement) {
@@ -48,4 +49,67 @@ For each identified item, suggest appropriate remediation options — blur, hide
     console.error(err);
     alert('Error analyzing image');
   }
+}
+
+async function compareImages() {
+  if (typeof LanguageModel === 'undefined') {
+    console.warn('LanguageModel API not available');
+    return;
+  }
+  try {
+    const session = await LanguageModel.create({
+      // { type: 'text' } only required when including expected input languages.
+      expectedInputs: [{ type: 'image' }],
+    });
+
+    const inputimage = await (await fetch(document.getElementById('preview').src)).blob();
+    const outputimage = await (await fetch(document.getElementById('outputImage').src)).blob();
+
+    const response1 = await session.prompt([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            value:
+              'Analyze the given input image to identify any items that may pose privacy, security, or compliance risks. Exclude faces from detection and focus strictly on objects such as:\n\nCredit cards or ID cards\n\nLaptops or screens displaying sensitive information\n\nDocuments, papers, or files with visible text\n\nWhiteboards containing meeting notes, client details, or other material information\n\nUse the Chrome Prompt API with the local on-device model to generate a processed output image. For each identified item, apply and document the remediation action taken — whether it was blurred, hidden, or replaced with a safe placeholder.\n\nAfter generating the output image, provide a comparison summary between input and output, explicitly noting the changes applied to sensitive objects. Finally, evaluate the processed image and state clearly whether it is now compliant for upload, or if further improvements are still needed before sharing on any public or social platform.',
+          },
+          { type: 'image', value: inputimage },
+          { type: 'image', value: outputimage },
+        ],
+      },
+    ]);
+
+    console.log(response1);
+    const analysisText =
+      response1?.output?.[0]?.content?.map((c) => c.text).join('\n') ||
+      'No response';
+    document.getElementById('analysisResult').textContent = analysisText;
+
+    const audioBlob = await captureMicrophoneInput({ seconds: 10 });
+    const response2 = await session.prompt([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', value: 'My response to your critique:' },
+          { type: 'audio', value: audioBlob },
+        ],
+      },
+    ]);
+    console.log(response2);
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+async function captureMicrophoneInput({ seconds }) {
+  const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  const recorder = new MediaRecorder(stream);
+  const chunks = [];
+  recorder.ondataavailable = (e) => chunks.push(e.data);
+  recorder.start();
+  await new Promise((resolve) => setTimeout(resolve, seconds * 1000));
+  recorder.stop();
+  await new Promise((resolve) => (recorder.onstop = resolve));
+  return new Blob(chunks, { type: 'audio/webm' });
 }

--- a/style.css
+++ b/style.css
@@ -76,3 +76,9 @@ button {
   color: #fff;
   cursor: pointer;
 }
+
+#analysisResult {
+  margin-top: 10px;
+  text-align: left;
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
## Summary
- enable comparing original and processed images using multimodal LanguageModel API
- capture microphone audio and submit follow-up prompt
- display model analysis in page and style analysis output

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ba300ef48323a447da7b7ef36ed4