### PR TITLE
Handle output language and remove unsupported audio use

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
   <div id="rightPane">
     <h2>Result</h2>
     <img id="outputImage" src="" alt="Output Image" style="display: none;" onclick="analyzeImage(this)" />
-    <pre id="analysisResult"></pre>
+    <textarea id="analysisResult" readonly style="display: none;"></textarea>
   </div>
 </div>
 

--- a/style.css
+++ b/style.css
@@ -79,6 +79,7 @@ button {
 
 #analysisResult {
   margin-top: 10px;
-  text-align: left;
-  white-space: pre-wrap;
+  width: 90%;
+  height: 120px;
+  resize: vertical;
 }


### PR DESCRIPTION
## Summary
- display model analysis in a textarea under the result image
- specify English output language for Chrome AI prompts
- drop microphone capture to avoid unsupported audio errors

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6becbdfa08323a0e76469da11527a