### PR TITLE
Fix response handling in compareImages

### DIFF
--- a/main.js
+++ b/main.js
@@ -57,9 +57,7 @@ async function compareImages() {
       },
     ]);
 
-    response1.then(r => {
-      document.getElementById("analysisResult").value = JSON.stringify(r, null, 2);
-    });
+    document.getElementById("analysisResult").value = JSON.stringify(response1, null, 2);
   } catch (err) {
     console.error(err);
   }


### PR DESCRIPTION
## Summary
- remove unnecessary `.then` on the awaited result from `session.prompt`
- directly display prompt response in the analysis textbox

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6dda9fd888323ac88901e06359ea0