### PR TITLE
Redesign interface with card layout and summary tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,35 +5,42 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>TagSense Privacy Filter (Prototype)</title>
   <link rel="stylesheet" href="./style.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
 </head>
 <body>
+  <header class="app-header">
+    <h1>TagSense Privacy Filter (Prototype)</h1>
+    <p class="subtitle">Protect sensitive details before sharing</p>
+  </header>
 
-<h1>TagSense Privacy Filter (Prototype)</h1>
+  <p class="intro">Click on an image to choose which sensitive objects to protect before sharing.</p>
 
-<p style="text-align: center;">Click on an image to choose which sensitive objects to protect before sharing.</p>
-
-<!-- Image selection gallery -->
-<div id="image-selector">
-  <div class="image-option">
-    <div class="img-title">Security Risk</div>
-    <img src="images/security.png" alt="Security Risk" onclick="selectImage(this)" />
+  <!-- Image selection gallery -->
+  <div id="image-selector" class="risk-cards">
+    <div class="risk-card" onclick="selectImage(this.querySelector('img'))">
+      <img src="images/security.png" alt="Security Risk" />
+      <div class="risk-label">Security Risk</div>
+    </div>
+    <div class="risk-card" onclick="selectImage(this.querySelector('img'))">
+      <img src="images/privacy.png" alt="Privacy Risk" />
+      <div class="risk-label">Privacy Risk</div>
+    </div>
+    <div class="risk-card" onclick="selectImage(this.querySelector('img'))">
+      <img src="images/compliance.png" alt="Compliance Risk" />
+      <div class="risk-label">Compliance Risk</div>
+    </div>
   </div>
-  <div class="image-option">
-    <div class="img-title">Privacy Risk</div>
-    <img src="images/privacy.png" alt="Privacy Risk" onclick="selectImage(this)" />
-  </div>
-  <div class="image-option">
-    <div class="img-title">Compliance Risk</div>
-    <img src="images/compliance.png" alt="Compliance Risk" onclick="selectImage(this)" />
-  </div>
-</div>
 
-<div id="app">
-  <div class="pane" id="originalPane">
-    <h2>Original</h2>
-    <img id="preview" src="" alt="Selected Image Preview" style="display: none;" />
-    <div id="controls">
-      <label for="actionSelect">Action:</label>
+  <div id="app">
+    <figure class="image-card" id="originalPane">
+      <figcaption>Unprocessed Image</figcaption>
+      <img id="preview" src="" alt="Selected Image Preview" style="display: none;" />
+    </figure>
+
+    <div id="controls" class="control-pane">
+      <label for="actionSelect">Remediation Option</label>
       <select id="actionSelect" disabled>
         <option value="blur">Blur</option>
         <option value="hide">Hide</option>
@@ -41,16 +48,24 @@
       </select>
       <button id="applyBtn" onclick="applyAction()" disabled>Apply</button>
     </div>
-  </div>
-  <div class="pane" id="resultPane">
-    <h2>Result</h2>
-    <img id="outputImage" src="" alt="Output Image" style="display: none;" />
-    <h3 id="summaryHeading" style="display: none;">Text Summary</h3>
-    <textarea id="analysisResult" readonly style="display: none;"></textarea>
-  </div>
-</div>
 
-<script src="./main.js"></script>
+    <figure class="image-card" id="resultPane">
+      <figcaption>Processed Image</figcaption>
+      <img id="outputImage" src="" alt="Output Image" style="display: none;" />
+      <div id="summarySection" style="display:none;">
+        <h3 id="summaryHeading">Input Image Risks</h3>
+        <div class="tabs">
+          <button class="tab-btn active" data-target="summaryBox">Summary</button>
+          <button class="tab-btn" data-target="rawBox">Raw Output</button>
+        </div>
+        <div id="summaryBox" class="tab-content active"></div>
+        <pre id="rawBox" class="tab-content"></pre>
+      </div>
+    </figure>
+  </div>
 
+  <footer class="app-footer">Built with Chrome Prompt API | TagSense Prototype – Hackathon 2025</footer>
+
+  <script src="./main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,17 +1,20 @@
 let selectedImageBase = "";
 
 function selectImage(imgElement) {
-  const thumbnails = document.querySelectorAll('#image-selector img');
-  thumbnails.forEach(img => img.classList.remove('selected'));
-  imgElement.classList.add('selected');
-  document.getElementById('preview').src = imgElement.src;
-  document.getElementById('preview').style.display = 'block';
+  const cards = document.querySelectorAll('.risk-card');
+  cards.forEach(card => card.classList.remove('selected'));
+  const card = imgElement.closest('.risk-card');
+  if (card) card.classList.add('selected');
+  const preview = document.getElementById('preview');
+  preview.src = imgElement.src;
+  preview.style.display = 'block';
   selectedImageBase = imgElement.src.replace(/^.*\/(.*)\.[^.]+$/, '$1');
   document.getElementById('actionSelect').disabled = false;
   document.getElementById('applyBtn').disabled = false;
   document.getElementById('outputImage').style.display = 'none';
-  document.getElementById('summaryHeading').style.display = 'none';
-  document.getElementById('analysisResult').style.display = 'none';
+  document.getElementById('summarySection').style.display = 'none';
+  document.getElementById('summaryBox').innerHTML = '';
+  document.getElementById('rawBox').textContent = '';
 }
 
 async function applyAction() {
@@ -21,22 +24,57 @@ async function applyAction() {
   const outImg = document.getElementById('outputImage');
   outImg.src = outputPath;
   outImg.style.display = 'block';
-  const analysisBox = document.getElementById('analysisResult');
-  analysisBox.style.display = 'block';
-  analysisBox.value = '';
-  const summaryHeading = document.getElementById('summaryHeading');
-  if (summaryHeading) summaryHeading.style.display = 'block';
+  document.getElementById('summarySection').style.display = 'block';
+  document.getElementById('summaryHeading').style.display = 'block';
+  document.getElementById('summaryBox').innerHTML = '';
+  document.getElementById('rawBox').textContent = '';
   await compareImages();
 }
 
+function markdownToHTML(md) {
+  const lines = md.split(/\r?\n/);
+  let html = '';
+  let inList = false;
+  lines.forEach(line => {
+    if (line.startsWith('- ') || line.startsWith('* ')) {
+      if (!inList) {
+        html += '<ul>';
+        inList = true;
+      }
+      html += `<li>${line.substring(2)}</li>`;
+    } else if (line.startsWith('### ')) {
+      if (inList) { html += '</ul>'; inList = false; }
+      html += `<h3>${line.substring(4)}</h3>`;
+    } else if (line.startsWith('## ')) {
+      if (inList) { html += '</ul>'; inList = false; }
+      html += `<h2>${line.substring(3)}</h2>`;
+    } else if (line.startsWith('# ')) {
+      if (inList) { html += '</ul>'; inList = false; }
+      html += `<h1>${line.substring(2)}</h1>`;
+    } else if (line.trim() === '') {
+      if (inList) { html += '</ul>'; inList = false; }
+    } else {
+      if (inList) { html += '</ul>'; inList = false; }
+      html += `<p>${line}</p>`;
+    }
+  });
+  if (inList) html += '</ul>';
+  return html;
+}
+
 async function compareImages() {
+  const summaryBox = document.getElementById('summaryBox');
+  const rawBox = document.getElementById('rawBox');
+  const defaultMessage =
+    'Chrome AI model not available on this device. To use TagSense, please enable and download the local Prompt API model in Chrome.';
   if (typeof LanguageModel === 'undefined') {
     console.warn('LanguageModel API not available');
+    if (summaryBox) summaryBox.innerText = defaultMessage;
+    if (rawBox) rawBox.textContent = defaultMessage;
     return;
   }
   try {
     const session = await LanguageModel.create({
-      // { type: 'text' } only required when including expected input languages.
       expectedInputs: [{ type: 'image' }],
       outputLanguage: 'en',
     });
@@ -58,8 +96,27 @@ async function compareImages() {
         ],
       },
     ]);
-    document.getElementById("analysisResult").value = JSON.stringify(response1, null, 2);
+    if (rawBox) rawBox.textContent = JSON.stringify(response1, null, 2);
+    const summaryText =
+      (Array.isArray(response1) && response1[0] && response1[0].content && response1[0].content[0] && response1[0].content[0].value) ||
+      '';
+    if (summaryBox) summaryBox.innerHTML = markdownToHTML(summaryText);
   } catch (err) {
     console.error(err);
+    if (summaryBox) summaryBox.innerText = defaultMessage;
+    if (rawBox) rawBox.textContent = defaultMessage;
   }
 }
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.tab-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+      const target = document.getElementById(btn.dataset.target);
+      if (target) target.classList.add('active');
+    });
+  });
+});
+

--- a/style.css
+++ b/style.css
@@ -1,57 +1,74 @@
 body {
-  font-family: Arial, sans-serif;
+  font-family: 'Inter', sans-serif;
   margin: 0;
-  padding: 20px;
-  background: #f5f7fa;
+  background: linear-gradient(180deg, #f9fafb 0%, #e9ecef 100%);
   color: #333;
-}
-
-h1 {
-  text-align: center;
-  color: #4a90e2;
-}
-
-#image-selector {
+  min-height: 100vh;
   display: flex;
-  justify-content: center;
-  gap: 15px;
+  flex-direction: column;
+}
+
+.app-header {
+  text-align: center;
+  padding: 20px 0 10px;
+}
+
+.subtitle {
+  font-size: 1rem;
+  color: #666;
+  margin-top: -10px;
+}
+
+.intro {
+  text-align: center;
   margin-bottom: 20px;
 }
 
-.image-option {
+.risk-cards {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 30px;
+}
+
+.risk-card {
+  background: #fff;
+  border: 2px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 10px;
   text-align: center;
-}
-
-.img-title {
-  font-weight: bold;
-  margin-bottom: 5px;
-  color: #4a90e2;
-}
-
-.image-option img {
-  width: 80px;
-  height: auto;
   cursor: pointer;
-  border: 2px solid transparent;
-  border-radius: 4px;
+  transition: transform 0.2s, box-shadow 0.2s;
 }
 
-.image-option img.selected {
-  border-color: #4a90e2;
+.risk-card:hover {
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  transform: translateY(-4px);
+}
+
+.risk-card.selected {
+  border-color: #1976d2;
+}
+
+.risk-card img {
+  width: 90px;
+  height: auto;
+}
+
+.risk-label {
+  margin-top: 8px;
+  font-weight: 600;
 }
 
 #app {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 30px;
-  max-width: 900px;
+  gap: 20px;
+  width: 100%;
+  max-width: 1100px;
   margin: 0 auto;
-}
-
-.pane {
-  flex: 1;
-  text-align: center;
+  flex-grow: 1;
 }
 
 @media (min-width: 768px) {
@@ -62,33 +79,99 @@ h1 {
   }
 }
 
-#preview, #outputImage {
-  max-width: 90%;
-  max-height: 100%;
+.image-card {
+  background: #fff;
+  border-radius: 12px;
+  padding: 15px;
+  text-align: center;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  flex: 1;
+}
+
+.image-card img {
+  max-width: 100%;
   border-radius: 8px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
 }
 
-#controls {
-  margin-top: 10px;
+.control-pane {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
 }
 
-select, button {
+@media (min-width: 768px) {
+  .control-pane {
+    width: 200px;
+  }
+}
+
+#controls label {
+  font-weight: 600;
+}
+
+#controls select {
   padding: 8px 12px;
-  border-radius: 4px;
-  border: none;
-  margin-right: 10px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
 }
 
-button {
-  background: #4a90e2;
+#applyBtn {
+  padding: 10px 20px;
+  background: #1976d2;
   color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 1rem;
   cursor: pointer;
 }
 
-#analysisResult {
-  margin-top: 10px;
-  width: 90%;
-  height: 120px;
-  resize: vertical;
+#applyBtn:disabled {
+  background: #90a4ae;
+  cursor: not-allowed;
 }
+
+.tabs {
+  display: flex;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.tab-btn {
+  padding: 6px 12px;
+  border: none;
+  background: #e0e0e0;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.tab-btn.active {
+  background: #1976d2;
+  color: #fff;
+}
+
+.tab-content {
+  display: none;
+  overflow-y: auto;
+  max-height: 150px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 10px;
+  background: #fff;
+  margin-top: 10px;
+  text-align: left;
+}
+
+.tab-content.active {
+  display: block;
+}
+
+.app-footer {
+  text-align: center;
+  padding: 15px;
+  font-size: 0.9rem;
+  color: #555;
+}
+


### PR DESCRIPTION
## Summary
- Center the title with a subtitle and modern font on a soft gradient background
- Turn risk selectors into hoverable cards and move remediation controls between image preview cards
- Replace markdown textarea with tabbed summary/raw view and add footer

## Testing
- `npm test` (fails: package.json missing)


------
https://chatgpt.com/codex/tasks/task_e_68c6f02ae9cc8323a1580e3671b6e8fd