### PR TITLE
Display raw output first and generate summary on demand

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,11 +55,11 @@
       <div id="summarySection" style="display:none;">
         <h3 id="summaryHeading">Input Image Risks</h3>
         <div class="tabs">
-          <button class="tab-btn active" data-target="summaryBox">Summary</button>
-          <button class="tab-btn" data-target="rawBox">Raw Output</button>
+          <button class="tab-btn active" data-target="rawBox">Raw Output</button>
+          <button id="summaryTab" class="tab-btn" data-target="summaryBox" disabled>Summary</button>
         </div>
-        <div id="summaryBox" class="tab-content active"></div>
-        <pre id="rawBox" class="tab-content"></pre>
+        <pre id="rawBox" class="tab-content active"></pre>
+        <div id="summaryBox" class="tab-content"></div>
       </div>
     </figure>
   </div>

--- a/style.css
+++ b/style.css
@@ -152,6 +152,11 @@ body {
   color: #fff;
 }
 
+.tab-btn:disabled {
+  background: #bdbdbd;
+  cursor: not-allowed;
+}
+
 .tab-content {
   display: none;
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- Show raw results before any summary and disable summary tab until data is ready
- Enable summary tab to call Chrome Summarizer API when clicked and render the response
- Style disabled tab buttons for better UX

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f54c37788323bbf67980d927d428